### PR TITLE
LRA: Fix for status and forget call failure by making parent LRA head…

### DIFF
--- a/lra/lrademo/flight-springboot/src/main/java/com/example/flightsb/FlightResource.java
+++ b/lra/lrademo/flight-springboot/src/main/java/com/example/flightsb/FlightResource.java
@@ -71,7 +71,7 @@ public class FlightResource {
 
     @RequestMapping(value = "/forget", method = RequestMethod.DELETE)
     @Forget
-    public ResponseEntity<?> forget(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(LRA_HTTP_PARENT_CONTEXT_HEADER) String parentLraID){
+    public ResponseEntity<?> forget(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(value = LRA_HTTP_PARENT_CONTEXT_HEADER, required = false) String parentLraID){
         LOG.info("Forget called");
         if(lraId == null){
             return new ResponseEntity<>("LRA header not present", HttpStatus.BAD_REQUEST);
@@ -86,7 +86,7 @@ public class FlightResource {
 
     @RequestMapping(value = "/status", method = RequestMethod.GET)
     @Status
-    public ResponseEntity<?> status(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(LRA_HTTP_PARENT_CONTEXT_HEADER) String parentLRA){
+    public ResponseEntity<?> status(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(value = LRA_HTTP_PARENT_CONTEXT_HEADER, required = false) String parentLRA){
         LOG.info("FlightServiceResource status() called for LRA : " + lraId);
         if (parentLRA != null) { // is the context nested
             // code which is sensitive to executing with a nested context goes here

--- a/lra/lrademo/hotel-springboot/src/main/java/com/example/hotelsb/HotelResource.java
+++ b/lra/lrademo/hotel-springboot/src/main/java/com/example/hotelsb/HotelResource.java
@@ -92,7 +92,7 @@ public class HotelResource {
 
     @RequestMapping(value = "/forget", method = RequestMethod.DELETE)
     @Forget
-    public ResponseEntity<?> forget(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(LRA_HTTP_PARENT_CONTEXT_HEADER) String parentLraID){
+    public ResponseEntity<?> forget(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(value = LRA_HTTP_PARENT_CONTEXT_HEADER, required = false) String parentLraID){
         LOG.info("Forget called");
         if(lraId == null){
             return new ResponseEntity<>("LRA header not present", HttpStatus.BAD_REQUEST);
@@ -107,7 +107,7 @@ public class HotelResource {
 
     @RequestMapping(value = "/status", method = RequestMethod.GET)
     @Status
-    public ResponseEntity<?> status(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(LRA_HTTP_PARENT_CONTEXT_HEADER) String parentLRA){
+    public ResponseEntity<?> status(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId, @RequestHeader(value = LRA_HTTP_PARENT_CONTEXT_HEADER, required = false) String parentLRA){
         LOG.info("HotelServiceResource status() called for LRA : " + lraId);
         if (parentLRA != null) { // is the context nested
             // code which is sensitive to executing with a nested context goes here


### PR DESCRIPTION
In SpringBoot all REST method parameters are mandatory by default. Participant methods `status` and `forget` was expecting `LRA_HTTP_PARENT_CONTEXT_HEADER` , which is not preset for non-nested LRA's, which leads to HTTP 400 code while calling these API's, due to which coordinator considers as failure and retries every time. As a fix, made LRA_HTTP_PARENT_CONTEXT_HEADER as optional header.