### PR TITLE
LRA Lock Free reservation issues fix due to quotes and missing dependency

### DIFF
--- a/lra/lockfree/springboot/flight-springboot/pom.xml
+++ b/lra/lockfree/springboot/flight-springboot/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>osdt_cert</artifactId>
             <version>21.13.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.saga</groupId>
+            <artifactId>saga-external-coordinator-api</artifactId>
+            <version>23.4.0</version>
+        </dependency>
 
         <!--        If this app is running on ARM based Mac, uncomment this.-->
 

--- a/lra/lockfree/springboot/flight-springboot/src/main/resources/application.properties
+++ b/lra/lockfree/springboot/flight-springboot/src/main/resources/application.properties
@@ -25,9 +25,9 @@ spring.microtx.lra.participant-url=http://localhost:8083
 spring.microtx.lra.headers-propagation-prefix = {x-b3-, oracle-tmm-, authorization, refresh-}
 spring.microtx.lra.lock-free-reservation-active=true
 
-departmentDataSource.url = "jdbc:oracle:thin:@tcps://<host>:<port>/<service_name>?wallet_location=Database_Wallet"
-departmentDataSource.user = "dbuser"
-departmentDataSource.password = "xxxxxx"
+departmentDataSource.url = jdbc:oracle:thin:@tcps://<host>:<port>/<service_name>?wallet_location=Database_Wallet
+departmentDataSource.user = dbuser
+departmentDataSource.password = xxxxxx
 # Properties for using Universal Connection Pool (UCP)
 # Note: These properties require JDBC version 21.0.0.0
 departmentDataSource.oracleucp.driver-class-name = oracle.jdbc.OracleDriver

--- a/lra/lockfree/springboot/hotel-springboot/pom.xml
+++ b/lra/lockfree/springboot/hotel-springboot/pom.xml
@@ -83,6 +83,11 @@
             <artifactId>osdt_cert</artifactId>
             <version>21.13.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.saga</groupId>
+            <artifactId>saga-external-coordinator-api</artifactId>
+            <version>23.4.0</version>
+        </dependency>
 
         <!--        If this app is running on ARM based Mac, uncomment this.-->
 

--- a/lra/lockfree/springboot/hotel-springboot/src/main/resources/application.properties
+++ b/lra/lockfree/springboot/hotel-springboot/src/main/resources/application.properties
@@ -25,9 +25,9 @@ spring.microtx.lra.participant-url=http://localhost:8082
 spring.microtx.lra.headers-propagation-prefix = {x-b3-, oracle-tmm-, authorization, refresh-}
 spring.microtx.lra.lock-free-reservation-active=true
 
-departmentDataSource.url = "jdbc:oracle:thin:@tcps://<host>:<port>/<service_name>?wallet_location=Database_Wallet"
-departmentDataSource.user = "dbuser"
-departmentDataSource.password = "xxxxxx"
+departmentDataSource.url = jdbc:oracle:thin:@tcps://<host>:<port>/<service_name>?wallet_location=Database_Wallet
+departmentDataSource.user = dbuser
+departmentDataSource.password = xxxxxx
 # Properties for using Universal Connection Pool (UCP)
 # Note: These properties require JDBC version 21.0.0.0
 departmentDataSource.oracleucp.driver-class-name = oracle.jdbc.OracleDriver

--- a/lra/lockfree/springboot/trip-manager-springboot/src/main/resources/application.properties
+++ b/lra/lockfree/springboot/trip-manager-springboot/src/main/resources/application.properties
@@ -28,9 +28,9 @@ spring.microtx.lra.lock-free-reservation-active=true
 hotel.service.url = http://localhost:8082/hotelService/api/hotel
 flight.service.url = http://localhost:8083/flightService/api/flight
 
-departmentDataSource.url = "jdbc:oracle:thin:@tcps://<host>:<port>/<service_name>?wallet_location=Database_Wallet"
-departmentDataSource.user = "dbuser"
-departmentDataSource.password = "xxxxxx"
+#departmentDataSource.url = jdbc:oracle:thin:@tcps://<host>:<port>/<service_name>?wallet_location=Database_Wallet
+#departmentDataSource.user = dbuser
+#departmentDataSource.password = xxxxxx
 # Properties for using Universal Connection Pool (UCP)
 # Note: These properties require JDBC version 21.0.0.0
 departmentDataSource.oracleucp.driver-class-name = oracle.jdbc.OracleDriver


### PR DESCRIPTION
LRA lock-free reservation samples were failing due to the below issues:
1. Quotes around data source config in application.properties file
2. saga-external-coordinator-api dependency was not mentioned in hotel & flight sample apps pom