### PR TITLE
All JPA application uses lazy connection injection

### DIFF
--- a/xa/java/department-helidon-jpa-eclipselink/src/main/java/com/oracle/mtm/sample/data/AccountsService.java
+++ b/xa/java/department-helidon-jpa-eclipselink/src/main/java/com/oracle/mtm/sample/data/AccountsService.java
@@ -44,15 +44,15 @@ public class AccountsService implements IAccountsService {
 
     @Inject
     @TrmEntityManager
-    private EntityManager entityManager;
+    private Provider<EntityManager> entityManager;
 
     @Inject
-    private Provider<EntityManager> localEntityManager;
+    private EntityManager localEntityManager;
 
     final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public Account findByAccountId(String accountId) throws SQLException {
-        EntityManager em = localEntityManager.get();
+        EntityManager em = localEntityManager;
         try {
             Query query = em.createNativeQuery("SELECT * FROM accounts where account_id= ?", Account.class);
             query.setParameter(1, accountId);
@@ -80,13 +80,13 @@ public class AccountsService implements IAccountsService {
 
     @Override
     public boolean withdraw(String accountId, double amount) throws SQLException {
-        Account account = findByAccountId(accountId, entityManager);
+        Account account = findByAccountId(accountId, entityManager.get());
         if (account != null) {
             logger.info("Current Balance: " + account.getAmount());
             account.setAmount(account.getAmount() - amount);
 
-            account = entityManager.merge(account);
-            entityManager.flush();
+            account = entityManager.get().merge(account);
+            entityManager.get().flush();
             logger.info("New Balance: " + account.getAmount());
             return true;
         }
@@ -95,12 +95,12 @@ public class AccountsService implements IAccountsService {
 
     @Override
     public boolean deposit(String accountId, double amount) throws SQLException {
-        Account account = findByAccountId(accountId, entityManager);
+        Account account = findByAccountId(accountId, entityManager.get());
         if (account != null) {
             logger.info("Current Balance: " + account.getAmount());
             account.setAmount(account.getAmount() + amount);
-            account = entityManager.merge(account);
-            entityManager.flush();
+            account = entityManager.get().merge(account);
+            entityManager.get().flush();
             logger.info("New Balance: " + account.getAmount());
             return true;
         }
@@ -110,7 +110,7 @@ public class AccountsService implements IAccountsService {
 
     @Override
     public double getBalance(String accountId) throws SQLException {
-        Account account = findByAccountId(accountId, entityManager);
+        Account account = findByAccountId(accountId, entityManager.get());
         if (account != null) {
             return account.getAmount();
         }

--- a/xa/java/teller-spring-promotion-jpa/pom.xml
+++ b/xa/java/teller-spring-promotion-jpa/pom.xml
@@ -47,7 +47,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate.orm</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+            </exclusions>
             <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.2.9.Final</version>
         </dependency>
         <dependency>
             <groupId>com.oracle.microtx</groupId>


### PR DESCRIPTION
To ensure that all the database information is properly loaded in MicroTx libray before the entity manager bean creation, the JPA application uses lazy injection.
Included the Hibernate version 6.2.9 in Teller spring Jpa promotion sample application